### PR TITLE
Better Testing, remove Flow

### DIFF
--- a/lib/config.ex
+++ b/lib/config.ex
@@ -58,4 +58,10 @@ defmodule KaufmannEx.Config do
   """
   @spec service_id() :: String.t()
   def service_id, do: System.get_env("HOST_NAME")
+
+  @doc """
+  Application.get_env(:kaufmann_ex, :event_handler_demand)
+  """
+  @spec service_id() :: integer()
+  def event_handler_demand, do: Application.get_env(:kaufmann_ex, :event_handler_demand, 50)
 end

--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -46,7 +46,7 @@ defmodule KaufmannEx.Publisher do
 
       KafkaEx.produce(produce_request)
     else
-      {:error, error} -> {:error, error}
+      error -> error
     end
   end
 

--- a/lib/schemas/event.ex
+++ b/lib/schemas/event.ex
@@ -12,9 +12,10 @@ defmodule KaufmannEx.Schemas.ErrorEvent do
   @type t :: %KaufmannEx.Schemas.ErrorEvent{
           name: atom,
           error: term,
-          message_payload: term
+          message_payload: term,
+          meta: term | nil
         }
 
   @moduledoc false
-  defstruct [:name, :error, :message_payload]
+  defstruct [:name, :error, :message_payload, meta: %{}]
 end

--- a/lib/stages/consumer.ex
+++ b/lib/stages/consumer.ex
@@ -1,0 +1,27 @@
+defmodule KaufmannEx.Stages.Consumer do
+  @moduledoc """
+  A consumer will be a consumer supervisor that will
+  Subscriber tasks for each event.
+  """
+
+  use ConsumerSupervisor
+
+  def start_link() do
+    ConsumerSupervisor.start_link(__MODULE__, :ok)
+  end
+
+  # Callbacks
+
+  def init(:ok) do
+    children = [
+      worker(KaufmannEx.Stages.EventHandler, [], restart: :temporary)
+    ]
+
+    # max_demand is highly resource dependent
+    {:ok, children,
+     strategy: :one_for_one,
+     subscribe_to: [
+       {KaufmannEx.Stages.Producer, max_demand: KaufmannEx.Config.event_handler_demand()}
+     ]}
+  end
+end

--- a/lib/stages/gen_consumer.ex
+++ b/lib/stages/gen_consumer.ex
@@ -1,4 +1,4 @@
-defmodule KaufmannEx.GenConsumer do
+defmodule KaufmannEx.Stages.GenConsumer do
   @moduledoc """
     `KafkaEx.GenConsumer` listening for Kafka messages. 
 

--- a/lib/subscriber.ex
+++ b/lib/subscriber.ex
@@ -85,7 +85,7 @@ defmodule KaufmannEx.Subscriber do
   defp error_from_event(event, error) do
     %KaufmannEx.Schemas.ErrorEvent{
       name: event.name,
-      error: error,
+      error: inspect(error),
       message_payload: event.payload
     }
   end

--- a/lib/subscriber.ex
+++ b/lib/subscriber.ex
@@ -82,6 +82,10 @@ defmodule KaufmannEx.Subscriber do
     end
   end
 
+  defp error_from_event(%KaufmannEx.Schemas.ErrorEvent{} = event, error) do
+    event
+  end
+
   defp error_from_event(event, error) do
     %KaufmannEx.Schemas.ErrorEvent{
       name: event.name,

--- a/lib/subscriber.ex
+++ b/lib/subscriber.ex
@@ -82,6 +82,7 @@ defmodule KaufmannEx.Subscriber do
     end
   end
 
+  # if loop of error events, just emit whatever we got
   defp error_from_event(%KaufmannEx.Schemas.ErrorEvent{} = event, error) do
     event
   end
@@ -90,7 +91,8 @@ defmodule KaufmannEx.Subscriber do
     %KaufmannEx.Schemas.ErrorEvent{
       name: event.name,
       error: inspect(error),
-      message_payload: event.payload
+      message_payload: event.payload,
+      meta: event.meta
     }
   end
 end

--- a/lib/supervisor.ex
+++ b/lib/supervisor.ex
@@ -29,12 +29,12 @@ defmodule KaufmannEx.Supervisor do
         start: {KaufmannEx.Stages.Producer, :start_link, []}
       },
       %{
-        id: KaufmannEx.Subscriber,
-        start: {KaufmannEx.Subscriber, :start_link, []}
+        id: KaufmannEx.Stages.Consumer,
+        start: {KaufmannEx.Stages.Consumer, :start_link, []}
       },
       %{
-        id: KafkaEx.ConsumerGroup,
-        start: {KafkaEx.ConsumerGroup, :start_link, consumer_group_opts},
+        id: KafkaEx.Stages.ConsumerGroup,
+        start: {KafkaEx.Stages.ConsumerGroup, :start_link, consumer_group_opts},
         type: :supervisor
       }
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -43,10 +43,10 @@ defmodule KaufmannEx.MixProject do
       # JSON lib
       {:poison, "~> 3.1"},
       # HTTP lib, overrride b/c some other libs specify older versions
-      {:httpoison, "~> 1.0", override: true},
+      {:httpoison, "~> 1.0"},
       {:nanoid, "~> 1.0"},
       {:avro_ex, "~> 0.1.0-beta.0"},
-      {:schemex, "~> 0.1.0"},
+      {:schemex, "~> 0.1.1"},
       {:credo, "~> 0.9.0-rc2", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
       {:benchwarmer, ">= 0.0.0", only: [:dev]},

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule KaufmannEx.MixProject do
   defp deps do
     [
       {:ex_doc, "~> 0.16", only: :dev, runtime: false},
-      {:flow, "~> 0.11"},
+      {:gen_stage, "~> 0.12"},
       # kafka Client
       {:kafka_ex, "~> 0.8.1"},
       # JSON lib

--- a/mix.lock
+++ b/mix.lock
@@ -34,7 +34,7 @@
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
-  "schemex": {:hex, :schemex, "0.1.0", "f7c1e8e78a7215d6e885f2c046eaf2c7f91adb400e56740229fadbcacc02447a", [:mix], [{:httpoison, "~> 0.12", [hex: :httpoison, repo: "hexpm", optional: false]}, {:poison, "~> 3.1", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "schemex": {:hex, :schemex, "0.1.1", "62d4fb3e61c940f23e7f37dbd74c0476ecae7fb9bf354e2e4731cb6e26d99ba8", [:mix], [{:httpoison, "~> 1.0", [hex: :httpoison, repo: "hexpm", optional: false]}, {:poison, "~> 3.1", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "snappy": {:git, "https://github.com/fdmanana/snappy-erlang-nif", "4e3b8611b6a1ff85a417b0f2fad8886c9485810e", []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},

--- a/test/mock_bus_test.exs
+++ b/test/mock_bus_test.exs
@@ -2,12 +2,14 @@ defmodule KaufmannEx.TestSupport.MockBusTest do
   use KaufmannEx.TestSupport.MockBus
 
   defmodule ExampleEventHandler do
-    def given_event(event) do
+    def given_event(%KaufmannEx.Schemas.Event{} = event) do
       case event.payload do
         "no_event" -> :ok
         _ -> KaufmannEx.Publisher.publish(event.name, event.payload)
       end
     end
+
+    def given_event(error_event), do: :ok
   end
 
   setup do

--- a/test/schemas_test.exs
+++ b/test/schemas_test.exs
@@ -35,7 +35,8 @@ defmodule KaufmannEx.SchemasTest do
       mock_get_fake_event(bypass, event_name, fake_schema)
       mock_get_metadata_schema(bypass)
 
-      {:error, :unmatching_schema} = Schemas.encode_message(event_name, %{"hello" => "world"})
+      {:error, :data_does_not_match_schema, _, _} =
+        Schemas.encode_message(event_name, %{"hello" => "world"})
     end
 
     test "when schema exists and is encodable", %{bypass: bypass} do

--- a/test/subscriber_test.exs
+++ b/test/subscriber_test.exs
@@ -1,4 +1,4 @@
-defmodule KaufmannEx.SubscriberTest do
+defmodule KaufmannEx.Stages.EventHandlerTest do
   use ExUnit.Case
   alias KaufmannEx.TestSupport.MockBus
   alias KafkaEx.Protocol.Fetch.Message
@@ -38,8 +38,8 @@ defmodule KaufmannEx.SubscriberTest do
     Process.register(self(), :subscriber)
 
     {:ok, pid} = KaufmannEx.Stages.Producer.start_link([])
-    {:ok, s_pid} = KaufmannEx.Subscriber.start_link([])
-    {:ok, state} = KaufmannEx.GenConsumer.init(@topic, @partition)
+    {:ok, s_pid} = KaufmannEx.Stages.Consumer.start_link()
+    {:ok, state} = KaufmannEx.Stages.GenConsumer.init(@topic, @partition)
 
     {:ok, bypass: bypass, state: state}
   end
@@ -51,7 +51,7 @@ defmodule KaufmannEx.SubscriberTest do
 
       event = encode_event(:"test.event.publish", "Hello")
 
-      KaufmannEx.GenConsumer.handle_message_set([event], state)
+      KaufmannEx.Stages.GenConsumer.handle_message_set([event], state)
 
       assert_receive :event_recieved
     end
@@ -63,7 +63,7 @@ defmodule KaufmannEx.SubscriberTest do
       first_event = encode_event(:"test.event.publish", "raise_error")
       second_event = encode_event(:"test.event.publish", "Hello")
 
-      KaufmannEx.GenConsumer.handle_message_set(
+      KaufmannEx.Stages.GenConsumer.handle_message_set(
         [
           first_event,
           second_event,


### PR DESCRIPTION
Replace GenStage/Flow behaviour in `subscriber` module with a `ConsumerSupervisor` module. The behaviour should be simpler to understand and reason about. Also errors are handled better and a single failing event won't block all events from processing.