### PR TITLE
Use Memoize to cache frequent GET calls to schema registry

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -45,4 +45,6 @@ config :kaufmann_ex,
   event_handler_mod: nil,
   producer_mod: KaufmannEx.Publisher,
   schema_path: "priv/schemas",
-  schema_registry_uri: System.get_env("SCHEMA_REGISTRY_PATH")
+  schema_registry_uri: System.get_env("SCHEMA_REGISTRY_PATH"),
+  service_name: "SampleService",
+  service_id: "SampleHost"

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -1,6 +1,19 @@
 defmodule KaufmannEx.Config do
   @moduledoc """
   Convenience Getters for pulling config.exs values
+
+  A config.exs may look like
+  ```
+  config :kaufmann_ex,
+    consumer_group: System.get_env("CONSUMER_GROUP"),
+    default_topic: System.get_env("KAFKA_TOPIC"),
+    event_handler_mod: nil,
+    producer_mod: KaufmannEx.Publisher,
+    schema_path: "priv/schemas",
+    schema_registry_uri: System.get_env("SCHEMA_REGISTRY_PATH"),
+    service_name: "SampleService"
+    service_id: System.get_env("HOSTNAME")
+  ```
   """
 
   @doc """
@@ -33,13 +46,13 @@ defmodule KaufmannEx.Config do
   `Application.get_env(:kaufmann_ex, :producer_mod)`
   """
   @spec producer_mod() :: String.t()
-  def producer_mod, do: Application.get_env(:kaufmann_ex, :producer_mod)
+  def producer_mod, do: Application.get_env(:kaufmann_ex, :producer_mod, KaufmannEx.Publisher)
 
   @doc """
   `Application.get_env(:kaufmann_ex, :schema_path)`
   """
   @spec schema_path() :: String.t()
-  def schema_path, do: Application.get_env(:kaufmann_ex, :schema_path)
+  def schema_path, do: Application.get_env(:kaufmann_ex, :schema_path, "priv/schemas")
 
   @doc """
   `Application.get_env(:kaufmann_ex, :schema_registry_uri)`
@@ -48,16 +61,16 @@ defmodule KaufmannEx.Config do
   def schema_registry_uri, do: Application.get_env(:kaufmann_ex, :schema_registry_uri)
 
   @doc """
-  `System.get_env("SERVICE_NAME")`
+  `Application.get_env(:kaufmann_ex, :service_name)`
   """
   @spec service_name() :: String.t()
-  def service_name, do: System.get_env("SERVICE_NAME")
+  def service_name, do: Application.get_env(:kaufmann_ex, :service_name)
 
   @doc """
-  `System.get_env("HOST_NAME")`
+  `Application.get_env(:kaufmann_ex, :service_id)`
   """
   @spec service_id() :: String.t()
-  def service_id, do: System.get_env("HOSTNAME")
+  def service_id, do:  Application.get_env(:kaufmann_ex, :service_id)
 
   @doc """
   Application.get_env(:kaufmann_ex, :event_handler_demand)

--- a/lib/schemas.ex
+++ b/lib/schemas.ex
@@ -1,15 +1,16 @@
 defmodule KaufmannEx.Schemas do
   @moduledoc """
-    Handles registration, retrieval, validation and parsing of Avro Schemas
+    Handles registration, retrieval, validation and parsing of Avro Schemas.
 
+    Schemas are cached to ETS table using `Memoize`. Does not handle schema changes while running. Best practice is to redeploy all services using a message schema if the schema changes.
 
-    Depends on 
+    Depends on
      - `Schemex` - calls to Confluent Schema Registry
      - `AvroEx` - serializing and deserializing avro encoded messages
+     - `Memoize` - Cache loading schemas to an ETS table, prevent performance bottleneck at schema registry.
   """
 
-  # Todo: Convert this module into a service that can cache loaded schemas
-
+  use Memoize
   require Logger
   require Map.Helpers
 
@@ -38,13 +39,65 @@ defmodule KaufmannEx.Schemas do
     end
   end
 
+  @doc """
+  Load schema from registry, inject metadata schema, parse into AvroEx schema
+
+  Memoized with permament caching.
+  """
+  defmemo parsed_schema(message_name), permanent: true  do
+    with {:ok, schema_name} <- if_partial_schema(message_name),
+         {:ok, %{"schema" => raw_schema}} <- get(schema_name),
+         {:ok, %{"schema" => metadata_schema}} <- get("event_metadata") do
+      AvroEx.parse_schema("[#{metadata_schema}, #{raw_schema}]")
+    end
+  end
+
+  defp if_partial_schema(message_name) do
+    event_string = message_name |> to_string
+
+    schema_name =
+      cond do
+        Regex.match?(~r/^query\./, event_string) ->
+          String.slice(event_string, 0..8)
+
+        Regex.match?(~r/^event\.error\./, event_string) ->
+          String.slice(event_string, 0..10)
+
+        true ->
+          event_string
+      end
+
+    {:ok, schema_name}
+  end
+
+  defp encode_message_with_schema(schema, message) do
+    AvroEx.encode(schema, message)
+  rescue
+    # avro_ex can become confused when trying to encode some schemas.
+    _ ->
+      {:error, :unmatching_schema}
+  end
+
+  defp decode_message_with_schema(schema, encoded) do
+    AvroEx.decode(schema, encoded)
+  rescue
+    # avro_ex can become confused when trying to decode some schemas.
+    _ ->
+      {:error, :unmatching_schema}
+  end
+
   defp atomize_keys({:ok, args}) do
     {:ok, Map.Helpers.atomize_keys(args)}
   end
 
   defp atomize_keys(args), do: args
 
-  def get(subject) do
+  @doc """
+  Get schema from registry
+
+  memoized permanetly
+  """
+  defmemo get(subject), permanent: true  do
     schema_registry_uri()
     |> Schemex.latest(subject)
   end
@@ -89,47 +142,5 @@ defmodule KaufmannEx.Schemas do
 
   defp schema_registry_uri do
     KaufmannEx.Config.schema_registry_uri()
-  end
-
-  defp encode_message_with_schema(schema, message) do
-    AvroEx.encode(schema, message)
-  rescue
-    # avro_ex can become confused when trying to encode some schemas. 
-    _ ->
-      {:error, :unmatching_schema}
-  end
-
-  defp decode_message_with_schema(schema, encoded) do
-    AvroEx.decode(schema, encoded)
-  rescue
-    # avro_ex can become confused when trying to decode some schemas. 
-    _ ->
-      {:error, :unmatching_schema}
-  end
-
-  defp parsed_schema(message_name) do
-    with {:ok, schema_name} <- if_partial_schema(message_name),
-         {:ok, %{"schema" => raw_schema}} <- get(schema_name),
-         {:ok, %{"schema" => metadata_schema}} <- get('event_metadata') do
-      AvroEx.parse_schema("[#{metadata_schema}, #{raw_schema}]")
-    end
-  end
-
-  defp if_partial_schema(message_name) do
-    event_string = message_name |> to_string
-
-    schema_name =
-      cond do
-        Regex.match?(~r/^query\./, event_string) ->
-          String.slice(event_string, 0..8)
-
-        Regex.match?(~r/^event\.error\./, event_string) ->
-          String.slice(event_string, 0..10)
-
-        true ->
-          event_string
-      end
-
-    {:ok, schema_name}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule KaufmannEx.MixProject do
   def project do
     [
       app: :kaufmann_ex,
-      version: "0.1.3",
+      version: "0.1.4",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -44,6 +44,7 @@ defmodule KaufmannEx.MixProject do
       {:avro_ex, "~> 0.1.0-beta.0"},
       {:schemex, "~> 0.1.1"},
       {:nanoid, "~> 1.0"},
+      {:memoize, "~> 1.2"},
       {:distillery, "~> 1.5", runtime: false},
       {:ex_doc, "~> 0.16", only: :dev, runtime: false},
       {:credo, "~> 0.9.0-rc2", only: [:dev, :test], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -25,6 +25,7 @@
   "jsx": {:hex, :jsx, "2.8.3", "a05252d381885240744d955fbe3cf810504eb2567164824e19303ea59eef62cf", [:mix, :rebar3], [], "hexpm"},
   "kafka_ex": {:hex, :kafka_ex, "0.8.1", "eea476ad1bca26604babe5cacfd67c843ca18a008d7116c8c21fce6974d662cd", [:mix], [], "hexpm"},
   "meck": {:hex, :meck, "0.8.9", "64c5c0bd8bcca3a180b44196265c8ed7594e16bcc845d0698ec6b4e577f48188", [:rebar3], [], "hexpm"},
+  "memoize": {:hex, :memoize, "1.2.5", "aa319c1a08d0564b5f69e4b190412ecab6e3a90b641663d46630e8d9778bb55c", [:mix], [], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [:mix], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},

--- a/test/schemas_test.exs
+++ b/test/schemas_test.exs
@@ -2,24 +2,39 @@ defmodule KaufmannEx.SchemasTest do
   use ExUnit.Case
   alias KaufmannEx.Schemas
 
-  setup do
-    previous_schema_uri = Application.get_env(:kaufmann_ex, :schema_registry_uri)
-    Application.put_env(:kaufmann_ex, :schema_registry_uri, "http://localhost:1188")
+  setup_all do
+    {:ok, memo_pid} = Application.ensure_all_started(:memoize)
 
-    on_exit(fn -> Application.put_env(:kaufmann_ex, :schema_registry_uri, previous_schema_uri) end)
+    # Clear cached schemas
+    on_exit(&Memoize.invalidate/0)
+
+    Application.put_env(:kaufmann_ex, :schema_registry_uri, "http://localhost:1188")
 
     bypass = Bypass.open(port: 1188)
 
+    # Mock calls to schema registry, only expected once
+    init_schema_cache(bypass, "test_event")
+
+    [bypass: bypass]
+  end
+
+  setup %{bypass: bypass} do
     encoded = <<2, 22, 104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100>>
-    {:ok, bypass: bypass, encoded: encoded}
+
+    {:ok, bypass: bypass, encoded: encoded, event_name: "test_event"}
+  end
+
+  def init_schema_cache(bypass, event_name) do
+    fake_schema = Poison.encode!(%{type: "string", name: "field"})
+
+    # bypass any http calls called time
+    mock_get_metadata_schema(bypass)
+    mock_get_fake_event(bypass, event_name, fake_schema)
+    mock_get_unkown_event(bypass)
   end
 
   describe "encode message" do
-    test "when schema isn't registered", %{bypass: bypass} do
-      Bypass.expect_once(bypass, "GET", "/subjects/UnknownEvent/versions/latest", fn conn ->
-        Plug.Conn.resp(conn, 404, ~s<{"error_code": "40401", "message": "Subject not found."}>)
-      end)
-
+    test "when schema isn't registered" do
       {:error, message} = Schemas.encode_message("UnknownEvent", %{hello: "world"})
 
       assert message ==
@@ -27,37 +42,19 @@ defmodule KaufmannEx.SchemasTest do
                 %{"error_code" => "40401", "message" => "Subject not found."}}
     end
 
-    test "when message doesn't match schema", %{bypass: bypass} do
-      event_name = "test_event"
-
-      fake_schema = Poison.encode!(%{type: "string", name: "field"})
-
-      mock_get_fake_event(bypass, event_name, fake_schema)
-      mock_get_metadata_schema(bypass)
-
+    test "when message doesn't match schema", %{event_name: event_name} do
       {:error, :data_does_not_match_schema, _, _} =
         Schemas.encode_message(event_name, %{"hello" => "world"})
     end
 
-    test "when schema exists and is encodable", %{bypass: bypass} do
-      event_name = "test_event"
-
-      fake_schema = Poison.encode!(%{type: "string", name: "field"})
-
-      mock_get_metadata_schema(bypass)
-      mock_get_fake_event(bypass, event_name, fake_schema)
-
+    test "when schema exists and is encodable", %{event_name: event_name} do
       {:ok, encoded} = Schemas.encode_message(event_name, "hello world")
       assert encoded == <<2, 22, 104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100>>
     end
   end
 
   describe "decode message" do
-    test "when schema isn't registered", %{bypass: bypass, encoded: encoded} do
-      Bypass.expect_once(bypass, "GET", "/subjects/UnknownEvent/versions/latest", fn conn ->
-        Plug.Conn.resp(conn, 404, ~s<{"error_code": "40401", "message": "Subject not found."}>)
-      end)
-
+    test "when schema isn't registered", %{encoded: encoded} do
       {:error, message} = Schemas.decode_message("UnknownEvent", encoded)
 
       assert message ==
@@ -66,7 +63,7 @@ defmodule KaufmannEx.SchemasTest do
     end
 
     test "when message doesn't match schema", %{bypass: bypass, encoded: encoded} do
-      event_name = "test_event"
+      event_name = "test_complex_event"
 
       fake_schema =
         Poison.encode!(%{
@@ -76,19 +73,14 @@ defmodule KaufmannEx.SchemasTest do
         })
 
       mock_get_fake_event(bypass, event_name, fake_schema)
-      mock_get_metadata_schema(bypass)
 
       {:error, :unmatching_schema} = Schemas.decode_message(event_name, encoded)
     end
 
-    test "when schema exists and message valid", %{bypass: bypass, encoded: encoded} do
-      event_name = "test_event"
-
-      fake_schema = Poison.encode!(%{type: "string", name: "field"})
-
-      mock_get_metadata_schema(bypass)
-      mock_get_fake_event(bypass, event_name, fake_schema)
-
+    test "when schema exists and message valid", %{
+      encoded: encoded,
+      event_name: event_name
+    } do
       {:ok, message} = Schemas.decode_message(event_name, encoded)
       assert message == "hello world"
     end
@@ -105,7 +97,6 @@ defmodule KaufmannEx.SchemasTest do
           ]
         })
 
-      mock_get_metadata_schema(bypass)
       mock_get_fake_event(bypass, event_name, fake_schema)
 
       {:ok, encoded} = Schemas.encode_message(event_name, %{hello: "world"})
@@ -116,7 +107,7 @@ defmodule KaufmannEx.SchemasTest do
   end
 
   def mock_get_fake_event(bypass, event_name, fake_schema) do
-    Bypass.expect(bypass, "GET", "/subjects/#{event_name}/versions/latest", fn conn ->
+    Bypass.expect_once(bypass, "GET", "/subjects/#{event_name}/versions/latest", fn conn ->
       Plug.Conn.resp(
         conn,
         200,
@@ -129,12 +120,18 @@ defmodule KaufmannEx.SchemasTest do
     {:ok, schema} = File.read('test/support/event_metadata.avsc')
     schema = schema |> Poison.decode!() |> Poison.encode!()
 
-    Bypass.expect(bypass, "GET", "/subjects/event_metadata/versions/latest", fn conn ->
+    Bypass.expect_once(bypass, "GET", "/subjects/event_metadata/versions/latest", fn conn ->
       Plug.Conn.resp(
         conn,
         200,
         Poison.encode!(%{subject: "event_metadata", version: 1, id: 1, schema: schema})
       )
+    end)
+  end
+
+  def mock_get_unkown_event(bypass) do
+    Bypass.expect_once(bypass, "GET", "/subjects/UnknownEvent/versions/latest", fn conn ->
+      Plug.Conn.resp(conn, 404, ~s<{"error_code": "40401", "message": "Subject not found."}>)
     end)
   end
 end

--- a/test/stages/producer_test.exs
+++ b/test/stages/producer_test.exs
@@ -2,7 +2,11 @@ defmodule KaufmannEx.Stages.ProducerTest do
   use ExUnit.Case
 
   setup do
-    {:ok, _} = KaufmannEx.Stages.Producer.start_link([])
+    case KaufmannEx.Stages.Producer.start_link([]) do
+      {:ok, _} -> :ok
+      {:error, {:already_started, _}} -> :ok
+      _ -> raise RuntimeError
+    end
 
     :ok
   end

--- a/test/subscriber_test.exs
+++ b/test/subscriber_test.exs
@@ -28,10 +28,23 @@ defmodule KaufmannEx.Stages.EventHandlerTest do
   @topic "topic"
   @partition 0
 
-  setup do
+  setup_all do
+    {:ok, memo_pid} = Application.ensure_all_started(:memoize)
+    # Clear cached schemas on exit
+    on_exit(&Memoize.invalidate/0)
+
     bypass = Bypass.open()
     Application.put_env(:kaufmann_ex, :schema_registry_uri, "http://localhost:#{bypass.port}")
 
+    # Mock calls to schema registry, only expected once
+    mock_get_metadata_schema(bypass)
+    mock_get_event_schema(bypass, "test.event.publish")
+
+
+    [bypass: bypass]
+  end
+
+  setup %{bypass: bypass} = context do
     Application.put_env(:kaufmann_ex, :event_handler_mod, TestEventHandler)
     Application.put_env(:kaufmann_ex, :schema_path, "test/support")
 
@@ -45,10 +58,7 @@ defmodule KaufmannEx.Stages.EventHandlerTest do
   end
 
   describe "when started" do
-    test "Consumes Events to EventHandler", %{bypass: bypass, state: state} do
-      mock_get_metadata_schema(bypass)
-      mock_get_event_schema(bypass, "test.event.publish")
-
+    test "Consumes Events to EventHandler", %{state: state} do
       event = encode_event(:"test.event.publish", "Hello")
 
       KaufmannEx.Stages.GenConsumer.handle_message_set([event], state)
@@ -56,10 +66,7 @@ defmodule KaufmannEx.Stages.EventHandlerTest do
       assert_receive :event_recieved
     end
 
-    test "handles errors gracefully", %{bypass: bypass, state: state} do
-      mock_get_metadata_schema(bypass)
-      mock_get_event_schema(bypass, "test.event.publish")
-
+    test "handles errors gracefully", %{state: state} do
       first_event = encode_event(:"test.event.publish", "raise_error")
       second_event = encode_event(:"test.event.publish", "Hello")
 
@@ -82,7 +89,7 @@ defmodule KaufmannEx.Stages.EventHandlerTest do
     {:ok, schema} = File.read("test/support/#{event_name}.avsc")
     schema = schema |> Poison.decode!() |> Poison.encode!()
 
-    Bypass.expect(bypass, "GET", "/subjects/#{event_name}/versions/latest", fn conn ->
+    Bypass.expect_once(bypass, "GET", "/subjects/#{event_name}/versions/latest", fn conn ->
       Plug.Conn.resp(
         conn,
         200,
@@ -95,7 +102,7 @@ defmodule KaufmannEx.Stages.EventHandlerTest do
     {:ok, schema} = File.read('test/support/event_metadata.avsc')
     schema = schema |> Poison.decode!() |> Poison.encode!()
 
-    Bypass.expect(bypass, "GET", "/subjects/event_metadata/versions/latest", fn conn ->
+    Bypass.expect_once(bypass, "GET", "/subjects/event_metadata/versions/latest", fn conn ->
       Plug.Conn.resp(
         conn,
         200,
@@ -103,6 +110,7 @@ defmodule KaufmannEx.Stages.EventHandlerTest do
       )
     end)
   end
+
 
   def encode_event(name, payload) do
     {:ok, encoded_event} = MockBus.encoded_event(name, payload)


### PR DESCRIPTION
Schemas are now cached for the lifetime of the service. 

Observing 30% increase in events/s in internal integration tests