### PR TITLE
Remove KafkaEx from KaufmannEx supervision tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ erl_crash.dump
 .elixir_ls/
 log/
 
+
+\.bash_history

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: elixir
 elixir:
-  - 1.6.1
+  - 1.7.3
 otp_release:
-  - 20.2
+  - 21.0
 
 env:
  global:
@@ -15,7 +15,7 @@ before_script:
 
 script:
   - if [ $PULL_REQUEST_ID != false ]; then pronto run -f github_pr; fi
-  - mix test
+  - mix test --no-start
 
 after_script:
   - mix deps.get --only docs

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ by adding `kaufmann_ex` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:kaufmann_ex, "~> 0.1.2"}
+    {:kafka_ex, , "~> 0.8.3"},
+    {:kaufmann_ex, "~> 0.3.0"}
   ]
 end
 ```
@@ -85,7 +86,10 @@ config :kafka_ex,
       9092
     }
   ],
-  consumer_group: "Consumer-Group"
+  consumer_group: "Consumer-Group",
+  commit_threshold: 10,
+  commit_interval: 100,
+  sync_timeout: 10_000
 ```
 
 ### `event_handler_mod`

--- a/config/config.exs
+++ b/config/config.exs
@@ -49,3 +49,6 @@ config :kaufmann_ex,
   service_name: "SampleService",
   service_id: "SampleHost",
   event_handler_demand: 50
+
+config :logger,
+  level: :info

--- a/config/config.exs
+++ b/config/config.exs
@@ -30,14 +30,12 @@ use Mix.Config
 #     import_config "#{Mix.env}.exs"
 
 config :kafka_ex,
-  brokers: [
-    {
-      System.get_env("KAFKA_HOST"),
-      9092
-    }
-  ],
+  brokers: System.get_env("KAFKA_BROKERS"),
   use_ssl: false,
-  consumer_group: System.get_env("CONSUMER_GROUP")
+  consumer_group: System.get_env("CONSUMER_GROUP"),
+  commit_threshold: 10,
+  commit_interval: 100,
+  sync_timeout: 10_000
 
 config :kaufmann_ex,
   consumer_group: System.get_env("CONSUMER_GROUP"),

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,18 +1,22 @@
-version: "2"
+version: "3.3"
 
 services:
   kaufmann:
     build:
       context: .
     environment: 
-      KAFKA_HOST: kafka
+      KAFKA_HOST: kafka-1
+      KAFKA_BROKERS: kafka-1:9092,kafka-2:9092,kafka-3:9092
       KAFKA_TOPIC: rapids
       CONSUMER_GROUP: test-consumer-group
       SCHEMA_REGISTRY_PATH: http://schema-registry:8081
       SERVICE_NAME: TEST
       HOST_NAME: docker-compose-test
+      HISTFILE: .bash_history
     depends_on: 
-      - kafka
+      - kafka-1
+      - kafka-2
+      - kafka-3
       - schema-registry
     volumes:
       - .:/app/kaufmann
@@ -21,18 +25,72 @@ services:
   kafka:
     image: spotify/kafka
     environment:
-      TOPICS: "rapids"
       NUM_PARTITIONS: 10
       AUTO_CREATE_TOPICS: 'true'
 
   schema-registry:
     image: confluentinc/cp-schema-registry
     depends_on:
-      - kafka
+      - kafka-1
     ports:
       - "8081:8081"
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
-      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: kafka:2181
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper:2181
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
 
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper
+    healthcheck:
+      test: echo stat | nc localhost 2181
+      interval: 10s
+      timeout: 10s
+      retries: 3
+    environment:
+    - ZOOKEEPER_SERVER_ID=1
+    - ZOOKEEPER_CLIENT_PORT=2181
+    - ZOOKEEPER_TICK_TIME=2000
+    - ZOOKEEPER_INIT_LIMIT=5
+    - ZOOKEEPER_SYNC_LIMIT=2
+    - ZOOKEEPER_SERVERS=zookeeper:2888:3888
+  kafka-1:
+    image: confluentinc/cp-kafka
+    healthcheck:
+      test: ps augwwx | egrep [S]upportedKafka
+    depends_on:
+    - zookeeper
+    environment:
+    - KAFKA_AUTO_CREATE_TOPICS=true
+    - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka-1:9092
+    - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092
+    - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+    - KAFKA_BROKER_ID=1
+    - BOOTSTRAP_SERVERS=kafka-1:9092,kafka-2:9092,kafka-3:9092
+    - ZOOKEEPER=zookeeper:2181
+  kafka-2:
+    image: confluentinc/cp-kafka
+    healthcheck:
+      test: ps augwwx | egrep [S]upportedKafka
+    depends_on:
+    - zookeeper
+    environment:
+    - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka-2:9092
+    - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092
+    - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+    - KAFKA_BROKER_ID=2
+    - BOOTSTRAP_SERVERS=kafka-1:9092,kafka-2:9092,kafka-3:9092
+    - ZOOKEEPER=zookeeper:2181
+  kafka-3:
+    image: confluentinc/cp-kafka
+    healthcheck:
+      test: ps augwwx | egrep [S]upportedKafka
+    depends_on:
+    - zookeeper
+    environment:
+    - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka-3:9092
+    - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092
+    - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+    - KAFKA_BROKER_ID=3
+    - BOOTSTRAP_SERVERS=kafka-1:9092,kafka-2:9092,kafka-3:9092
+    - ZOOKEEPER=zookeeper:2181

--- a/lib/publisher/partition_selector.ex
+++ b/lib/publisher/partition_selector.ex
@@ -84,9 +84,9 @@ defmodule KaufmannEx.Publisher.PartitionSelector do
   end
 
   def get_partitions_count(topic) do
-    %KafkaEx.Protocol.Metadata.Response{
+    %{
       topic_metadatas: [
-        %KafkaEx.Protocol.Metadata.TopicMetadata{
+        %{
           partition_metadatas: partition_metadatas
         }
       ]
@@ -96,7 +96,7 @@ defmodule KaufmannEx.Publisher.PartitionSelector do
   end
 
   def fetch_partitions_counts do
-    %KafkaEx.Protocol.Metadata.Response{topic_metadatas: topics} = KafkaEx.metadata()
+    %{topic_metadatas: topics} = KafkaEx.metadata()
 
     topics
     |> Enum.map(&extract_partition_count/1)

--- a/lib/schemas.ex
+++ b/lib/schemas.ex
@@ -74,7 +74,8 @@ defmodule KaufmannEx.Schemas do
     AvroEx.encode(schema, message)
   rescue
     # avro_ex can become confused when trying to encode some schemas.
-    _ ->
+    error ->
+      Logger.debug(["Could not encode schema \n\t", inspect(error)])
       {:error, :unmatching_schema}
   end
 

--- a/lib/stages/event_handler.ex
+++ b/lib/stages/event_handler.ex
@@ -28,7 +28,7 @@ defmodule KaufmannEx.Stages.EventHandler do
       |> error_from_event(error)
       |> handler.given_event()
 
-      reraise error, error.stacktrace()
+      reraise error, __STACKTRACE__
   end
 
   @doc """

--- a/lib/stages/event_handler.ex
+++ b/lib/stages/event_handler.ex
@@ -8,44 +8,52 @@ defmodule KaufmannEx.Stages.EventHandler do
 
   def start_link(event) do
     Task.start_link(fn ->
-      event
-      |> decode_event()
-      |> handle_with_rescue()
+      handle_event(event)
     end)
-  end
-
-  def handle_with_rescue(event) do
-    handle_event(event)
-  rescue
-    error ->
-      Logger.warn("Error Consuming #{event.name} #{inspect(error)}")
-      handler = KaufmannEx.Config.event_handler()
-
-      event
-      |> error_from_event(error)
-      |> handler.given_event()
   end
 
   def handle_event(event) do
     handler = KaufmannEx.Config.event_handler()
-    handler.given_event(event)
+
+    event
+    |> decode_event()
+    |> handler.given_event()
+  rescue
+    error ->
+      Logger.warn("Error Consuming #{event.key} #{inspect(error)}")
+      handler = KaufmannEx.Config.event_handler()
+
+      event
+      |> decode_event()
+      |> error_from_event(error)
+      |> handler.given_event()
+
+      reraise error, error.stacktrace()
   end
 
   @doc """
-  Decodes Avro encoded message value, transforms event into tuple of `{:message_name, %Payload{}}`
+  Decodes Avro encoded message value
 
-  Returns `{key, value}`
+  Returns Event or Error
   """
   @spec decode_event(map) :: KaufmannEx.Schemas.Event.t() | KaufmannEx.Schemas.ErrorEvent.t()
-  def decode_event(%{key: key, value: value}) do
+  def decode_event(%{key: key, value: value} = event) do
     event_name = key |> String.to_atom()
 
     case KaufmannEx.Schemas.decode_message(key, value) do
-      {:ok, parsed} ->
+      {:ok, %{meta: meta, payload: payload}} ->
+        Logger.debug([
+          meta[:message_name],
+          " ",
+          meta[:message_id],
+          " from ",
+          meta[:emitter_service_id]
+        ])
+
         %KaufmannEx.Schemas.Event{
           name: event_name,
-          meta: parsed[:meta],
-          payload: parsed[:payload]
+          meta: meta,
+          payload: payload
         }
 
       {:error, error} ->

--- a/lib/supervisor.ex
+++ b/lib/supervisor.ex
@@ -13,7 +13,7 @@ defmodule KaufmannEx.Supervisor do
     Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
-  def init(opts \\ [strategy: :one_for_all]) do
+  def init(opts \\ []) do
     consumer_group_name = KaufmannEx.Config.consumer_group()
     topics = KaufmannEx.Config.default_topics()
     gen_consumer_mod = KaufmannEx.Config.gen_consumer_mod()
@@ -26,10 +26,6 @@ defmodule KaufmannEx.Supervisor do
     ]
 
     children = [
-      %{
-        id: KafkaEx,
-        start: {KafkaEx, :start, [[], []]}
-      },
       %{
         id: KaufmannEx.Stages.Producer,
         start: {KaufmannEx.Stages.Producer, :start_link, []}
@@ -49,6 +45,6 @@ defmodule KaufmannEx.Supervisor do
       }
     ]
 
-    Supervisor.init(children, strategy: :one_for_all)
+    Supervisor.init(children, strategy: :one_for_one)
   end
 end

--- a/lib/test_support/mock_bus.ex
+++ b/lib/test_support/mock_bus.ex
@@ -75,7 +75,9 @@ defmodule KaufmannEx.TestSupport.MockBus do
     try do
       Process.unregister(:producer)
     rescue
-      _ -> # Nothing else to be done
+      # Nothing else to be done
+      _ ->
+        nil
     end
 
     Application.put_env(:kaufmann_ex, :producer_mod, producer_mod)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule KaufmannEx.MixProject do
   def project do
     [
       app: :kaufmann_ex,
-      version: "0.2.3-alpha",
+      version: "0.3.0-beta",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -32,8 +32,7 @@ defmodule KaufmannEx.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger],
-      included_applications: [:kafka_ex]
+      extra_applications: [:logger]
     ]
   end
 
@@ -48,14 +47,14 @@ defmodule KaufmannEx.MixProject do
       {:schemex, "~> 0.1.1"},
       {:nanoid, "~> 1.0"},
       {:memoize, "~> 1.2"},
-      {:distillery, "~> 1.5", runtime: false},
       {:ex_doc, "~> 0.16", only: :dev, runtime: false},
       {:credo, "~> 0.9.1", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
       {:bypass, "~> 0.8", only: :test},
       {:excoveralls, "~> 0.8", only: :test},
-      {:mix_test_watch, "~> 0.5", only: :dev, runtime: false},
-      {:inch_ex, only: :docs}
+      {:inch_ex, only: :docs},
+      {:benchee, "~> 0.11", only: [:dev, :test]},
+      {:mock, "~> 0.3.0", only: [:test]}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "avro_ex": {:git, "https://github.com/CJPoll/avro_ex.git", "36375d431439a2eb1c23fc4029f4ca44b49cb97e", []},
+  "benchee": {:hex, :benchee, "0.13.2", "30cd4ff5f593fdd218a9b26f3c24d580274f297d88ad43383afe525b1543b165", [:mix], [{:deep_merge, "~> 0.1", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm"},
   "benchwarmer": {:hex, :benchwarmer, "0.0.2", "902e5c020608647b07c38b82103e4af6d2667dfd5d5d13c67382238de6943136", [:mix], [], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "bypass": {:hex, :bypass, "0.8.1", "16d409e05530ece4a72fabcf021a3e5c7e15dcc77f911423196a0c551f2a15ca", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: false]}, {:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
@@ -8,6 +9,7 @@
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
   "credo": {:hex, :credo, "0.9.3", "76fa3e9e497ab282e0cf64b98a624aa11da702854c52c82db1bf24e54ab7c97a", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "decimal": {:hex, :decimal, "1.5.0", "b0433a36d0e2430e3d50291b1c65f53c37d56f83665b43d79963684865beab68", [:mix], [], "hexpm"},
+  "deep_merge": {:hex, :deep_merge, "0.2.0", "c1050fa2edf4848b9f556fba1b75afc66608a4219659e3311d9c9427b5b680b3", [:mix], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "distillery": {:hex, :distillery, "1.5.2", "eec18b2d37b55b0bcb670cf2bcf64228ed38ce8b046bb30a9b636a6f5a4c0080", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},

--- a/sample_application/mix.exs
+++ b/sample_application/mix.exs
@@ -22,14 +22,16 @@ defmodule Sample.Mixfile do
 
   def deps do
     [
+      {:kafka_ex, "~> 0.8.3"},
       {:kaufmann_ex, path: ".."}
+      
     ]
   end
 
 
   defp aliases do
     [
-      test: "test --exclude integration"
+      test: "test --no-start --exclude integration"
     ]
   end
 end

--- a/sample_application/mix.lock
+++ b/sample_application/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "avro_ex": {:hex, :avro_ex, "0.1.0-beta.5", "4e3e4892edb437deda8ad99da8b874458eb45a7d03ca99a4ba5b3bf2352fa26e", [:mix], [{:ecto, "~> 2.1.0 or ~> 2.2.0", [hex: :ecto, repo: "hexpm", optional: false]}, {:poison, "~> 3.1.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "avro_ex": {:git, "https://github.com/CJPoll/avro_ex.git", "36375d431439a2eb1c23fc4029f4ca44b49cb97e", []},
   "certifi": {:hex, :certifi, "2.3.1", "d0f424232390bf47d82da8478022301c561cf6445b5b5fb6a84d49a9e76d2639", [:rebar3], [{:parse_trans, "3.2.0", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "decimal": {:hex, :decimal, "1.5.0", "b0433a36d0e2430e3d50291b1c65f53c37d56f83665b43d79963684865beab68", [:mix], [], "hexpm"},
   "distillery": {:hex, :distillery, "1.5.2", "eec18b2d37b55b0bcb670cf2bcf64228ed38ce8b046bb30a9b636a6f5a4c0080", [:mix], [], "hexpm"},
@@ -8,7 +8,7 @@
   "hackney": {:hex, :hackney, "1.12.1", "8bf2d0e11e722e533903fe126e14d6e7e94d9b7983ced595b75f532e04b7fdc7", [:rebar3], [{:certifi, "2.3.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.1", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpoison": {:hex, :httpoison, "1.1.1", "96ed7ab79f78a31081bb523eefec205fd2900a02cda6dbc2300e7a1226219566", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.1.1", "cbc3b2fa1645113267cc59c760bafa64b2ea0334635ef06dbac8801e42f7279c", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
-  "kafka_ex": {:git, "https://github.com/kafkaex/kafka_ex.git", "b87732d1c912831236ae527c17a2a9dc5ef16b05", []},
+  "kafka_ex": {:hex, :kafka_ex, "0.8.3", "16946ec8c50adf8ff5b858b28cff85ed93b16785004b2be1c9959cd2d704a462", [:mix], [], "hexpm"},
   "memoize": {:hex, :memoize, "1.2.7", "fd435d76496717561dc14af9135def1a9d5cab400939bf2b784764fabafe1655", [:mix], [], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},

--- a/test/integration/benchmarks/simple_consumer_bench.exs
+++ b/test/integration/benchmarks/simple_consumer_bench.exs
@@ -1,0 +1,217 @@
+# Simple benchmark of standrad KafkaEx GenConsumer vs KaufmannEx Stages.Consumer.
+# In Sequential mode, get very similar performance
+
+# Expects to be run in integration test mode with running kafka, zookeeper and schema registry
+# $ mix test test/integration/benchmarks/simple_consumer_bench.exs --include integration
+# Name                                  ips        average  deviation         median         99th %
+# kaufmannex publish and wait        841.71        1.19 ms  ±1324.85%        0.64 ms        4.40 ms
+# simple publish and wait            797.63        1.25 ms  ±1283.08%        0.67 ms        4.31 ms
+
+
+Name                                  ips        average  deviation         median         99th %
+kaufmannex publish and wait        861.38        1.16 ms  ±1318.39%        0.62 ms        4.11 ms
+simple publish and wait            785.88        1.27 ms  ±1275.77%        0.69 ms        4.43 ms
+
+Comparison:
+kaufmannex publish and wait        861.38
+simple publish and wait            785.88 - 1.10x slower
+
+
+defmodule IntegrationTest.SimpleGenConsumerSubscriber do
+  use KafkaEx.GenConsumer
+  require Logger
+
+  def init(_topic, _partition) do
+    {:ok, {}}
+  end
+
+  def handle_message_set(message_set, state) do
+    message_set
+    |> Enum.map(&KaufmannEx.Stages.EventHandler.handle_event/1)
+
+    {:async_commit, state}
+  end
+
+  def publish(pid) do
+    message_body = %{
+      payload: %{message: pid_to_binary(pid)},
+      meta: %{
+        message_id: Nanoid.generate(),
+        emitter_service: KaufmannEx.Config.service_name(),
+        emitter_service_id: KaufmannEx.Config.service_id(),
+        callback_id: nil,
+        message_name: "command.test",
+        timestamp: DateTime.to_string(DateTime.utc_now()),
+        callback_topic: nil
+      }
+    }
+
+    :ok = KaufmannEx.Publisher.publish(:"command.test", message_body)
+  end
+
+  def given_event(%{name: :"command.test", payload: %{message: pid}} = event) do
+    # Process.sleep(400)
+
+    pid
+    |> pid_from_string()
+    |> send({:hello, pid})
+  end
+
+  def given_event(other) do
+    IO.inspect(other, label: "Unhandled event")
+  end
+
+  def publish_and_wait(__), do: publish_and_wait()
+
+  def publish_and_wait do
+    :ok = publish(self())
+
+    receive do
+      {:hello, pid} -> Logger.debug("Publish Callback received")
+    after
+      2000 ->
+        {:error, :timeout}
+    end
+  end
+
+  # Thanks to https://github.com/koudelka/visualixir/blob/master/lib/visualixir/tracer.ex
+  defp pid_to_binary(pid) when is_pid(pid) do
+    "#PID" <> (pid |> :erlang.pid_to_list() |> :erlang.list_to_binary())
+  end
+
+  def pid_from_string("#PID" <> string) do
+    string
+    |> :erlang.binary_to_list()
+    |> :erlang.list_to_pid()
+  end
+end
+
+defmodule IntegrationTest.KaufmannExSubscriberListener do
+  require Logger
+
+  def publish(pid) do
+    message_body = %{
+      payload: %{message: pid_to_binary(pid)},
+      meta: %{
+        message_id: Nanoid.generate(),
+        emitter_service: KaufmannEx.Config.service_name(),
+        emitter_service_id: KaufmannEx.Config.service_id(),
+        callback_id: nil,
+        message_name: "command.test",
+        timestamp: DateTime.to_string(DateTime.utc_now()),
+        callback_topic: nil
+      }
+    }
+
+    :ok = KaufmannEx.Publisher.publish(:"command.test", message_body)
+  end
+
+  def given_event(%{name: :"command.test", payload: %{message: pid}} = event) do
+    # Process.sleep(400)
+
+    pid
+    |> pid_from_string()
+    |> send({:hello, pid})
+  end
+
+  def given_event(other) do
+    IO.inspect(other, label: "Unhandled event")
+  end
+
+  def publish_and_wait(__), do: publish_and_wait()
+
+  def publish_and_wait do
+    :ok = publish(self())
+
+    receive do
+      {:hello, pid} ->
+        {:ok, nil}
+    after
+      2000 ->
+        {:error, :timeout}
+    end
+  end
+
+  # Thanks to https://github.com/koudelka/visualixir/blob/master/lib/visualixir/tracer.ex
+  defp pid_to_binary(pid) when is_pid(pid) do
+    "#PID" <> (pid |> :erlang.pid_to_list() |> :erlang.list_to_binary())
+  end
+
+  def pid_from_string("#PID" <> string) do
+    string
+    |> :erlang.binary_to_list()
+    |> :erlang.list_to_pid()
+  end
+end
+
+defmodule IntegrationTest.IngrationBenchmarkTest do
+  use ExUnit.Case
+  import Mock
+
+  @moduletag :integration
+
+  setup_all do
+    KaufmannEx.ReleaseTasks.migrate_schemas("sample_application/priv/schemas/")
+
+    # Ensure topic is defined, raise error if not 
+    KafkaEx.metadata(topic: "rapids")
+
+    Process.sleep(1000)
+  end
+
+  def setup_kaufmann_supervisor(event_handler_mod, consumer_mod) do
+    Application.put_env(
+      :kaufmann_ex,
+      :event_handler_mod,
+      event_handler_mod
+    )
+
+    Application.put_env(
+      :kaufmann_ex,
+      :gen_consumer_mod,
+      consumer_mod
+    )
+  end
+
+  # @tag skip: "Enable to bench throughput of publish to consumer"
+  test "Bench Run" do
+    # Name                                  ips        average  deviation         median         99th %
+    # kaufmannex publish and wait        841.71        1.19 ms  ±1324.85%        0.64 ms        4.40 ms
+    # simple publish and wait            797.63        1.25 ms  ±1283.08%        0.67 ms        4.31 ms
+
+              {:ok, sup} = Supervisor.start_link([], [strategy: :one_for_one, max_restarts: 1_000_000, max_seconds: 1])
+
+    Benchee.run(
+      %{
+        "simple publish and wait" =>
+          {&IntegrationTest.SimpleGenConsumerSubscriber.publish_and_wait/1,
+           input: {
+               IntegrationTest.SimpleGenConsumerSubscriber,
+               IntegrationTest.SimpleGenConsumerSubscriber
+             }},
+        "kaufmannex publish and wait" => {
+          &IntegrationTest.KaufmannExSubscriberListener.publish_and_wait/1,
+          input: {
+              IntegrationTest.KaufmannExSubscriberListener,
+              KaufmannEx.Stages.GenConsumer
+            }
+          
+        }
+      },
+      # parallel: 3,
+      before_scenario: fn ({event_mod, consumer_mod}) ->
+        setup_kaufmann_supervisor(
+              event_mod,
+              consumer_mod
+            )
+        Supervisor.start_child(sup, Supervisor.child_spec(KaufmannEx.Supervisor, [])) 
+      end,
+      after_scenario: fn _ ->
+        id = KaufmannEx.Supervisor
+        with :ok <- Supervisor.terminate_child(sup, id),
+             :ok <- Supervisor.delete_child(sup, id),
+            do: :ok
+      end
+    )
+  end
+end

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -1,0 +1,130 @@
+defmodule IntegrationTest.SubscriberListener do
+  require Logger
+
+  def publish(pid) do
+    message_body = %{
+      payload: %{message: pid_to_binary(pid)},
+      meta: %{
+        message_id: Nanoid.generate(),
+        emitter_service: KaufmannEx.Config.service_name(),
+        emitter_service_id: KaufmannEx.Config.service_id(),
+        callback_id: nil,
+        message_name: "command.test",
+        timestamp: DateTime.to_string(DateTime.utc_now()),
+        callback_topic: nil
+      }
+    }
+
+    :ok = KaufmannEx.Publisher.publish(:"command.test", message_body)
+  end
+
+  def given_event(%{name: :"command.test", payload: %{message: pid}} = event) do
+    # Process.sleep(400)
+
+    pid
+    |> pid_from_string()
+    |> send({:hello, pid})
+  end
+
+  def given_event(other) do
+    IO.inspect(other, label: "Unhandled event")
+  end
+
+  def publish_and_wait do
+    :ok = publish(self())
+
+    receive do
+      {:hello, pid} -> Logger.debug("Publish Callback received")
+    after
+      2000 ->
+        {:error, :timeout}
+    end
+  end
+
+  # Thanks to https://github.com/koudelka/visualixir/blob/master/lib/visualixir/tracer.ex
+  defp pid_to_binary(pid) when is_pid(pid) do
+    "#PID" <> (pid |> :erlang.pid_to_list() |> :erlang.list_to_binary())
+  end
+
+  def pid_from_string("#PID" <> string) do
+    string
+    |> :erlang.binary_to_list()
+    |> :erlang.list_to_pid()
+  end
+end
+
+defmodule IntegrationTest do
+  use ExUnit.Case
+  import Mock
+
+  @moduletag :integration
+
+  setup_all do
+    KaufmannEx.ReleaseTasks.migrate_schemas("sample_application/priv/schemas/")
+
+    Application.put_env(
+      :kaufmann_ex,
+      :event_handler_mod,
+      IntegrationTest.SubscriberListener
+    )
+
+    # Ensure topic is defined, raise error if not 
+    KafkaEx.metadata(topic: "rapids")
+
+    Process.sleep(1000)
+
+    # Start supervision tree
+    {:ok, kaufmann_supervisor} = start_supervised(KaufmannEx.Supervisor)
+
+    Process.sleep(4000)
+
+    # Ensure subscriber is working 
+    IntegrationTest.SubscriberListener.publish_and_wait()
+
+    [kaufmann_supervisor: kaufmann_supervisor]
+  end
+
+  test "publish and consume" do
+    assert :ok = IntegrationTest.SubscriberListener.publish(self())
+
+    assert_receive {:hello, _}
+  end
+
+  describe "GenConsumer handles timeout" do
+    test "inspection of supervision tree", %{kaufmann_supervisor: kaufmann_supervisor} do
+      {KafkaEx.ConsumerGroup, k_consumer_group, :supervisor, [KafkaEx.ConsumerGroup]} =
+        kaufmann_supervisor
+        |> Supervisor.which_children()
+        |> Enum.find(fn
+          {KafkaEx.ConsumerGroup, _, _, _} -> true
+          _ -> false
+        end)
+
+      assert [
+               {:consumer, _, :supervisor, [KafkaEx.GenConsumer.Supervisor]},
+               {KafkaEx.ConsumerGroup.Manager, _, :worker, [KafkaEx.ConsumerGroup.Manager]}
+             ] = Supervisor.which_children(k_consumer_group)
+
+      assert %{active: 4, specs: 4, supervisors: 1, workers: 3} =
+               Supervisor.count_children(kaufmann_supervisor)
+    end
+
+    test "when KafakEx.GenConsumer receives timeout", %{kaufmann_supervisor: kaufmann_supervisor} do
+      # Updates state, continues
+      {KafkaEx.ConsumerGroup, k_consumer_group, :supervisor, [KafkaEx.ConsumerGroup]} =
+        kaufmann_supervisor
+        |> Supervisor.which_children()
+        |> Enum.find(fn
+          {KafkaEx.ConsumerGroup, _, _, _} -> true
+          _ -> false
+        end)
+
+      consumer =
+        k_consumer_group
+        |> KafkaEx.ConsumerGroup.consumer_pids()
+        |> Enum.at(0)
+
+      send(consumer, :timeout)
+    end
+  end
+end

--- a/test/release_tasks/reinit_test.exs
+++ b/test/release_tasks/reinit_test.exs
@@ -44,12 +44,14 @@ defmodule KaufmannEx.ReleaseTasks.ReInitTest do
       Process.register(self(), :reinit)
       :ok = ReInit.GenConsumer.handle_message_set(message_set, state)
 
-      assert_received :shutdown, ":reinit process should recieve shutdown once max offset is reached"
+      assert_received :shutdown,
+                      ":reinit process should recieve shutdown once max offset is reached"
     end
   end
 
   def set_partition_0_offset(offset) do
     :ok = Application.ensure_started(:kafka_ex)
+
     res =
       KafkaEx.offset_commit(:kafka_ex, %KafkaEx.Protocol.OffsetCommit.Request{
         consumer_group: Config.consumer_group(),


### PR DESCRIPTION
KafkeEx was supervised by KaufmannEx.Supervisor. This may have introduced bug #21 

This is a breaking change. Any application relying on KaufmannEx starting KafkaEx will need to ensure KafkaEx is now started by normal startup. 