### PR TITLE
Allow for multiple `from` senders in KaufmannEx.Stages.Producer

### DIFF
--- a/test/stages/producer_test.exs
+++ b/test/stages/producer_test.exs
@@ -39,7 +39,7 @@ defmodule KaufmannEx.Stages.ProducerTest do
     end
 
     test "When demand changes over multiple calls" do
-      from = {self(), :test}
+      from = MapSet.new([{self(), :test}])
 
       {reply, next_message_set, state} =
         KaufmannEx.Stages.Producer.handle_demand(5, %{


### PR DESCRIPTION
My initial implementation assumed only 1 source of events (i.e. one partition) This worked OK for a while. Noticed today, this may be a source of some pretty weird errors in GenConsumer.