### PR TITLE
Select single transcoder in MockSchemaRegistry

### DIFF
--- a/lib/kaufmann_ex/test_support/mock_schema_registry.ex
+++ b/lib/kaufmann_ex/test_support/mock_schema_registry.ex
@@ -29,6 +29,18 @@ defmodule KaufmannEx.TestSupport.MockSchemaRegistry do
   end
 
   @spec encode_decode(Request.t()) :: Event.t()
+  def encode_decode(%Request{format: format} = request) when format == :json or format == :avro do
+    transcoder = Config.transcoder(format)
+
+    %Request{encoded: encoded, event_name: event_name, metadata: meta} =
+      transcoder.encode_event(request)
+
+    transcoder.decode_event(%Event{
+      raw_event: %{key: event_name, value: encoded, offset: 0},
+      meta: meta
+    })
+  end
+
   def encode_decode(%Request{} = request) do
     %Request{encoded: encoded, event_name: event_name, metadata: meta} = brute_encode(request)
 

--- a/lib/kaufmann_ex/test_support/mock_schema_registry.ex
+++ b/lib/kaufmann_ex/test_support/mock_schema_registry.ex
@@ -5,6 +5,8 @@ defmodule KaufmannEx.TestSupport.MockSchemaRegistry do
   Looks for Schemas at `Application.get_env(:kaufmann_ex, :schema_path)`
   """
 
+  import ExUnit.Assertions
+
   alias KaufmannEx.Config
   alias KaufmannEx.Publisher.Request
   alias KaufmannEx.Schemas.Event
@@ -35,6 +37,11 @@ defmodule KaufmannEx.TestSupport.MockSchemaRegistry do
   def encode_decode(%Request{format: format} = request) do
     transcoder = Config.transcoder(format)
 
+    assert transcoder, """
+      undefined format: #{inspect(format)}
+      Format must match a transcoder specified in Application env `:kaufmann_ex, :transcoder`
+    """
+
     %Request{encoded: encoded, event_name: event_name, metadata: meta} =
       transcoder.encode_event(request)
 
@@ -43,5 +50,4 @@ defmodule KaufmannEx.TestSupport.MockSchemaRegistry do
       meta: meta
     })
   end
-
 end


### PR DESCRIPTION
if format is provided in the request, select transcoder to encode and decode instead brute.