### PR TITLE
Improve passing extra arguments to eventhandler

### DIFF
--- a/lib/kaufmann_ex/consumer/flow.ex
+++ b/lib/kaufmann_ex/consumer/flow.ex
@@ -22,8 +22,6 @@ defmodule KaufmannEx.Consumer.Flow do
       |> Flow.from_stages(stages: Config.stages(), max_demand: Config.max_demand())
       # wrap events into our event struct
       |> Flow.map(fn event ->
-        Logger.info("Consumed Event #{event.key} from #{topic}##{partition}")
-
         %Event{
           raw_event: event,
           topic: topic,
@@ -36,7 +34,7 @@ defmodule KaufmannEx.Consumer.Flow do
       |> Flow.flat_map(&TopicSelector.resolve_topic/1)
       |> Flow.map(&Encoder.encode_event/1)
       |> Flow.map(&Publisher.publish_request(&1, [worker]))
-      |> Flow.start_link(name: String.to_atom("flow_#{topic}_#{partition}"))
+      |> Flow.start_link(name: Module.concat([__MODULE__, producer_stage]))
 
     {:ok, link_pid}
   end

--- a/lib/kaufmann_ex/consumer/flow.ex
+++ b/lib/kaufmann_ex/consumer/flow.ex
@@ -34,7 +34,7 @@ defmodule KaufmannEx.Consumer.Flow do
       |> Flow.flat_map(&TopicSelector.resolve_topic/1)
       |> Flow.map(&Encoder.encode_event/1)
       |> Flow.map(&Publisher.publish_request(&1, [worker]))
-      |> Flow.start_link(name: Module.concat([__MODULE__, producer_stage]))
+      |> Flow.start_link(name: flow_name(producer_stage))
 
     {:ok, link_pid}
   end
@@ -44,5 +44,13 @@ defmodule KaufmannEx.Consumer.Flow do
       {:ok, pid} -> {:ok, pid}
       {:error, {:already_started, pid}} -> {:ok, pid}
     end
+  end
+
+  defp flow_name(producer) when is_atom(producer) do
+    Module.concat([__MODULE__, producer])
+  end
+
+  defp flow_name(producer) when is_pid(producer) do
+    Module.concat([__MODULE__, inspect(producer)])
   end
 end

--- a/lib/kaufmann_ex/consumer/gen_consumer.ex
+++ b/lib/kaufmann_ex/consumer/gen_consumer.ex
@@ -32,7 +32,7 @@ defmodule KaufmannEx.Consumer.GenConsumer do
     # Filter out unhandled events before decoding
     # Decode each event
     |> Enum.map(&Event.decode_event/1)
-    |> Enum.flat_map(&EventHandler.handle_event(&1, event_handler))
+    |> Enum.flat_map(&EventHandler.handle_event(&1, Enum.to_list(state)))
     |> Enum.flat_map(&TopicSelector.resolve_topic/1)
     |> Enum.map(&Encoder.encode_event/1)
     |> Enum.each(&Publisher.publish_request/1)

--- a/lib/kaufmann_ex/event_handler.ex
+++ b/lib/kaufmann_ex/event_handler.ex
@@ -136,13 +136,16 @@ defmodule KaufmannEx.EventHandler do
 
     results = handle_event_and_response(event, args)
 
-    report_telemetry(start_time: start_time, event: event)
+    report_telemetry(
+      start_time: start_time,
+      event: event,
+      event_handler: (args || [])[:event_handler]
+    )
 
     Enum.flat_map(results, &format_event(event, &1))
   end
 
   defp handle_event_and_response(event, args) do
-
     event_handler = Keyword.get(args || [], :event_handler, Config.event_handler())
 
     event_name = Map.get(event, :name, nil)

--- a/lib/kaufmann_ex/event_handler.ex
+++ b/lib/kaufmann_ex/event_handler.ex
@@ -97,9 +97,11 @@ defmodule KaufmannEx.EventHandler do
       end
 
       def given_event(event), do: {:unhandled, []}
+      def given_event(event, _meta), do: given_event(event)
 
       defoverridable handled_events: 0,
-                     given_event: 1
+                     given_event: 1,
+                     given_event: 2
     end
   end
 
@@ -138,10 +140,12 @@ defmodule KaufmannEx.EventHandler do
     Enum.flat_map(results, &format_event(event, &1))
   end
 
-  defp handle_event_and_response(event, event_handler) do
+  defp handle_event_and_response(event, args) do
+    event_handler = Keyword.get(args, :event_handler, Config.event_handler())
+
     event_name = Map.get(event, :name, nil)
 
-    case event_handler.given_event(event) do
+    case event_handler.given_event(event, args) do
       {:reply, events} when is_list(events) ->
         events
 

--- a/lib/kaufmann_ex/event_handler.ex
+++ b/lib/kaufmann_ex/event_handler.ex
@@ -131,18 +131,19 @@ defmodule KaufmannEx.EventHandler do
   defp dig_for_binary(_), do: []
 
   @spec handle_event(Event.t(), atom) :: [any]
-  def handle_event(event, event_handler) do
+  def handle_event(event, args) do
     start_time = System.monotonic_time()
 
-    results = handle_event_and_response(event, event_handler)
+    results = handle_event_and_response(event, args)
 
-    report_telemetry(start_time: start_time, event: event, event_handler: event_handler)
+    report_telemetry(start_time: start_time, event: event)
 
     Enum.flat_map(results, &format_event(event, &1))
   end
 
   defp handle_event_and_response(event, args) do
-    event_handler = Keyword.get(args, :event_handler, Config.event_handler())
+
+    event_handler = Keyword.get(args || [], :event_handler, Config.event_handler())
 
     event_name = Map.get(event, :name, nil)
 

--- a/lib/kaufmann_ex/event_handler.ex
+++ b/lib/kaufmann_ex/event_handler.ex
@@ -166,7 +166,7 @@ defmodule KaufmannEx.EventHandler do
           |> Enum.at(0)
           |> String.to_atom()
 
-        handle_event_and_response(%Event{event | name: event_name}, event_handler)
+        handle_event_and_response(%Event{event | name: event_name}, args)
 
       {:error, error} ->
         wrap_error_event(event, error)

--- a/lib/kaufmann_ex/event_handler.ex
+++ b/lib/kaufmann_ex/event_handler.ex
@@ -61,6 +61,7 @@ defmodule KaufmannEx.EventHandler do
   ```
 
   """
+  alias KaufmannEx.Config
   alias KaufmannEx.Publisher.Request
   alias KaufmannEx.Schemas.Event
 

--- a/lib/kaufmann_ex/event_handler.ex
+++ b/lib/kaufmann_ex/event_handler.ex
@@ -130,7 +130,7 @@ defmodule KaufmannEx.EventHandler do
   defp dig_for_binary(bin) when is_binary(bin), do: [bin]
   defp dig_for_binary(_), do: []
 
-  @spec handle_event(Event.t(), atom) :: [any]
+  @spec handle_event(Event.t(), list) :: [any]
   def handle_event(event, args) do
     start_time = System.monotonic_time()
 

--- a/lib/kaufmann_ex/publisher/request.ex
+++ b/lib/kaufmann_ex/publisher/request.ex
@@ -10,7 +10,8 @@ defmodule KaufmannEx.Publisher.Request do
     encoded: nil,
     context: %{},
     format: :default,
-    topic: :default
+    topic: :default,
+    worker_name: nil
   )
 
   @type t :: %__MODULE__{
@@ -21,6 +22,7 @@ defmodule KaufmannEx.Publisher.Request do
           topic: binary | atom | map,
           partition: non_neg_integer | nil,
           format: atom,
-          encoded: binary | nil
+          encoded: binary | nil,
+          worker_name: atom | nil
         }
 end

--- a/lib/kaufmann_ex/supervisor.ex
+++ b/lib/kaufmann_ex/supervisor.ex
@@ -42,7 +42,8 @@ defmodule KaufmannEx.Supervisor do
                auto_offset_reset: :latest,
                fetch_options: [
                  max_bytes: 1_971_520,
-                 wait_time: 100
+                 wait_time: 100,
+                 auto_commit: false
                ],
                commit_strategy: :async_commit,
                # passed through to the ConsumerGroup.Manager

--- a/lib/kaufmann_ex/supervisor.ex
+++ b/lib/kaufmann_ex/supervisor.ex
@@ -24,6 +24,7 @@ defmodule KaufmannEx.Supervisor do
     consumer_group_id = Keyword.get(opts, :id, KaufmannEx.ConsumerGroup)
     manager_name = Keyword.get(opts, :manager_name, KaufmannEx.ConsumerGroup.Manager)
     gen_server_opts = Keyword.get(opts, :gen_server_opts, [])
+    extra_consumer_args = Keyword.get(opts, :extra_consumer_args, [])
 
     children = [
       %{
@@ -44,8 +45,10 @@ defmodule KaufmannEx.Supervisor do
                  wait_time: 100
                ],
                commit_strategy: :async_commit,
-               name: manager_name, # passed through to the ConsumerGroup.Manager
-               gen_server_opts: gen_server_opts
+               # passed through to the ConsumerGroup.Manager
+               name: manager_name,
+               gen_server_opts: gen_server_opts,
+               extra_consumer_args: extra_consumer_args
              ]
            ]},
         type: :supervisor

--- a/lib/kaufmann_ex/test_support/mock_bus.ex
+++ b/lib/kaufmann_ex/test_support/mock_bus.ex
@@ -49,9 +49,12 @@ defmodule KaufmannEx.TestSupport.MockBus do
 
   # handle case of unnamed event
   def given_event(payload) do
-    handle_and_send_event(%Event{
-      payload: payload
-    }, [])
+    handle_and_send_event(
+      %Event{
+        payload: payload
+      },
+      []
+    )
   end
 
   @doc """
@@ -59,11 +62,8 @@ defmodule KaufmannEx.TestSupport.MockBus do
 
   Schema must be defined & payload must be valid/enocodable
   """
-  @spec given_event(atom | binary, any, binary | list | nil) :: :ok
+  @spec given_event(atom | binary, any, list) :: :ok
   def given_event(event_name, payload, opts \\ [])
-
-  def given_event(event_name, payload, callback_id) when is_binary(callback_id),
-    do: given_event(event_name, payload, callback_id: callback_id)
 
   def given_event(event_name, payload, opts) do
     schema_name = schema_name_if_query(event_name)

--- a/lib/kaufmann_ex/transcoder/seven_avro/schema.ex
+++ b/lib/kaufmann_ex/transcoder/seven_avro/schema.ex
@@ -11,6 +11,7 @@ defmodule KaufmannEx.Transcoder.SevenAvro.Schema do
   rescue
     # avro_ex can become confused when trying to decode some schemas.
     error ->
+      Logger.debug("Error decoding event #{key} with Avro, trying AvroV0")
       # Previous versions of AvroEx have some quirkey decoding behavior
       v0_decode(schema, encoded, key)
   end
@@ -21,8 +22,9 @@ defmodule KaufmannEx.Transcoder.SevenAvro.Schema do
   rescue
     # avro_ex can become confused when trying to decode some schemas.
     error ->
-      trace = Exception.format(:error, error, __STACKTRACE__)
-      Logger.warn("Could not decode event \n\t #{trace}")
+      Logger.debug("Error decoding event #{key} with AvroV0 giving up")
+      # trace = Exception.format(:error, error, __STACKTRACE__)
+      # Logger.debug("Could not decode event \n\t #{trace}")
 
       {:error, :unmatching_schema}
   end
@@ -32,9 +34,9 @@ defmodule KaufmannEx.Transcoder.SevenAvro.Schema do
   rescue
     # avro_ex can become confused when trying to encode some schemas.
     error ->
-      trace = Exception.format(:error, error, __STACKTRACE__)
+      # trace = Exception.format(:error, error, __STACKTRACE__)
 
-      Logger.warn("Could not encode event \n\t #{trace}")
+      # Logger.debug("Could not encode event \n\t #{trace}")
       {:error, :unmatching_schema}
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -25,7 +25,7 @@
   "inch_ex": {:hex, :inch_ex, "2.0.0", "24268a9284a1751f2ceda569cd978e1fa394c977c45c331bb52a405de544f4de", [:mix], [{:bunt, "~> 0.2", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "kafka_ex": {:git, "https://github.com/kafkaex/kafka_ex", "08e91caaaf2e79b676b822efedbcd90c3bbe518e", []},
-  "kafka_ex_gen_stage_consumer": {:git, "https://github.com/sevenmind/kafka_ex_gen_stage_consumer", "7cf7f4a83af081ac59f8fdf8ece6cf3d56a2985d", []},
+  "kafka_ex_gen_stage_consumer": {:git, "https://github.com/sevenmind/kafka_ex_gen_stage_consumer", "e81c2dd9adb40ea2904a151ec0415513d2955ae1", []},
   "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "meck": {:hex, :meck, "0.8.13", "ffedb39f99b0b99703b8601c6f17c7f76313ee12de6b646e671e3188401f7866", [:rebar3], [], "hexpm"},

--- a/mix.lock
+++ b/mix.lock
@@ -25,7 +25,7 @@
   "inch_ex": {:hex, :inch_ex, "2.0.0", "24268a9284a1751f2ceda569cd978e1fa394c977c45c331bb52a405de544f4de", [:mix], [{:bunt, "~> 0.2", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "kafka_ex": {:git, "https://github.com/kafkaex/kafka_ex", "08e91caaaf2e79b676b822efedbcd90c3bbe518e", []},
-  "kafka_ex_gen_stage_consumer": {:git, "https://github.com/sevenmind/kafka_ex_gen_stage_consumer", "3b26c8f3066a868b638409de1f3df8fa32f7b656", []},
+  "kafka_ex_gen_stage_consumer": {:git, "https://github.com/sevenmind/kafka_ex_gen_stage_consumer", "7cf7f4a83af081ac59f8fdf8ece6cf3d56a2985d", []},
   "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "meck": {:hex, :meck, "0.8.13", "ffedb39f99b0b99703b8601c6f17c7f76313ee12de6b646e671e3188401f7866", [:rebar3], [], "hexpm"},

--- a/test/consumer/flow_test.exs
+++ b/test/consumer/flow_test.exs
@@ -6,8 +6,8 @@ defmodule KaufmannEx.Consumer.FlowTest do
   defmodule GenProducer do
     use GenStage
 
-    def start_link(number) do
-      GenStage.start_link(__MODULE__, number)
+    def start_link(state) do
+      GenStage.start_link(__MODULE__, state)
     end
 
     def init(counter) do

--- a/test/event_handler_test.exs
+++ b/test/event_handler_test.exs
@@ -91,7 +91,7 @@ defmodule KaufmannEx.EventHandlerTest do
              ] =
                EventHandler.handle_event(
                  %Event{name: :"event.with.response", payload: %{}, meta: %{}},
-                 TestEventHandler
+                 event_handler: TestEventHandler
                )
     end
 
@@ -103,7 +103,7 @@ defmodule KaufmannEx.EventHandlerTest do
                    payload: %{},
                    meta: %{}
                  },
-                 TestEventHandler
+                 event_handler: TestEventHandler
                )
     end
 
@@ -123,7 +123,7 @@ defmodule KaufmannEx.EventHandlerTest do
                    payload: "raise_error",
                    meta: %{}
                  },
-                 TestEventHandler
+                 event_handler: TestEventHandler
                )
     end
 
@@ -140,7 +140,7 @@ defmodule KaufmannEx.EventHandlerTest do
                    payload: %{},
                    meta: %{}
                  },
-                 TestEventHandler
+                 event_handler: TestEventHandler
                )
     end
 
@@ -152,7 +152,7 @@ defmodule KaufmannEx.EventHandlerTest do
             payload: %{},
             meta: %{}
           },
-          TestEventHandler
+          event_handler: TestEventHandler
         )
 
       assert length(res) == 3


### PR DESCRIPTION
This PR fixes passing arguments through to a KaufmannEx consumer. Changes from implementing re-use of kaufmann in dynamic supervision instead of statically supervised in Application.Supervisor spec 